### PR TITLE
fix: remove redundant sidebar search panel from advanced filters

### DIFF
--- a/frontend/components/search/AdvancedFilters.tsx
+++ b/frontend/components/search/AdvancedFilters.tsx
@@ -40,7 +40,6 @@ export function AdvancedFilters({
   onTagToggle,
 }: AdvancedFiltersProps) {
   const [expandedSections, setExpandedSections] = useState({
-    search: true,
     types: true,
     tags: true,
     date: false,
@@ -51,7 +50,6 @@ export function AdvancedFilters({
   };
 
   const activeFilterCount =
-    (filters.searchQuery ? 1 : 0) +
     filters.resourceTypes.length +
     selectedTags.length +
     (filters.dateRange ? 1 : 0);
@@ -109,23 +107,6 @@ export function AdvancedFilters({
       </CardHeader>
 
       <CardContent className="space-y-4">
-        {/* Search Query */}
-        <FilterSection
-          title="Search"
-          isExpanded={expandedSections.search}
-          onToggle={() => toggleSection('search')}
-          isActive={!!filters.searchQuery}
-        >
-          <Input
-            placeholder="Title, description..."
-            value={filters.searchQuery}
-            onChange={(e) =>
-              onFilterChange({ ...filters, searchQuery: e.target.value })
-            }
-            className="text-sm"
-          />
-        </FilterSection>
-
         {/* Resource Type */}
         <FilterSection
           title="Resource Type"


### PR DESCRIPTION
## Bug Fix: Redundant Sidebar Search Panel

### Issue
Two search bars were displaying on the search page:
1. Main search bar at top of page
2. Duplicate search panel in sidebar filters

This created confusion and redundancy in the UI.

### Changes
- Removed duplicate search input from sidebar filter panel
- Consolidated to single main search bar at top
- Removed 'search' from expandedSections state
- Updated activeFilterCount logic

### Testing
- [x] Only one search bar visible
- [x] Sidebar shows only: Resource Type, Tags, Upload Date
- [x] Search functionality works via main input
- [x] No console errors

### Before & After
**Before:** Two search inputs (main + sidebar)
**After:** Single search input at top, cleaner UI